### PR TITLE
Add example to render to a framebuffer and save as png

### DIFF
--- a/0.3/multi-threaded_search/Cargo.toml
+++ b/0.3/multi-threaded_search/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "milti-threaded_search"
+name = "multi-threaded_search"
 version = "0.1.0"
 authors = ["13r0ck <>"]
 edition = "2018"

--- a/0.3/render_to_framebuffer_and_save/Cargo.toml
+++ b/0.3/render_to_framebuffer_and_save/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "render_to_frambuffer_and_save"
+version = "0.1.0"
+authors = ["TheRittler <>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+iced = "0.3"
+iced_wgpu = "0.4.0"
+iced_winit = "0.3.0"
+png = "0.16.8"

--- a/0.3/render_to_framebuffer_and_save/README.md
+++ b/0.3/render_to_framebuffer_and_save/README.md
@@ -3,6 +3,8 @@ The purpose of this example is, to render a GUI to an off-screen framebuffer and
 
 It is based on [this](https://github.com/hecrj/iced/tree/master/examples/integration) Iced example in combination with [this](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/capture) wgpu example.
 
+![Screenshot of GUI](https://user-images.githubusercontent.com/12140954/122641248-5b7e2480-d104-11eb-9852-ef621ebe9a71.png)
+
 ## What this does
 It simply renders an arbitrary Iced app (in this case a simple counter app) to a framebuffer. Afterwards the buffer is saved to the disk as a png.
 

--- a/0.3/render_to_framebuffer_and_save/README.md
+++ b/0.3/render_to_framebuffer_and_save/README.md
@@ -1,0 +1,141 @@
+# Render to Framebuffer and Save as Image
+The purpose of this example is, to render a GUI to an off-screen framebuffer and save it to an image. So, it is possible to create "screenshots" of an app without actually opening a window of the OS.
+
+It is based on [this](https://github.com/hecrj/iced/tree/master/examples/integration) Iced example in combination with [this](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/capture) wgpu example.
+
+## What this does
+It simply renders an arbitrary Iced app (in this case a simple counter app) to a framebuffer. Afterwards the buffer is saved to the disk as a png.
+
+## How it works
+
+1. A wgpu adapter as well as an output buffer are created
+```rust
+    let adapter = wgpu::Instance::new(wgpu::BackendBit::PRIMARY)
+        .request_adapter(&wgpu::RequestAdapterOptions::default())
+        .await
+        .unwrap();
+
+    let (mut device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                label: None,
+                features: wgpu::Features::empty(),
+                limits: wgpu::Limits::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // It is a WebGPU requirement that ImageCopyBuffer.layout.bytes_per_row % wgpu::COPY_BYTES_PER_ROW_ALIGNMENT == 0
+    // So we calculate padded_bytes_per_row by rounding unpadded_bytes_per_row
+    // up to the next multiple of wgpu::COPY_BYTES_PER_ROW_ALIGNMENT.
+    // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+    let buffer_dimensions = BufferDimensions::new(width, height);
+    // The output buffer lets us retrieve the data as an array
+    let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (buffer_dimensions.padded_bytes_per_row * buffer_dimensions.height) as u64,
+        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        mapped_at_creation: false,
+    });
+```
+
+2. A texture is created, on which the GUI will be drawn. Also some other objects like the encoder are created which are needed by the renderer.
+```rust
+
+    let texture_extent = wgpu::Extent3d {
+        width: buffer_dimensions.width as u32,
+        height: buffer_dimensions.height as u32,
+        depth: 1
+    };
+
+    // The render pipeline renders data into this texture
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: texture_extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+        label: None,
+    });
+
+    let mut debug = Debug::new();
+    let mut renderer = Renderer::new(Backend::new(&mut device, Settings::default()));
+
+    // Initialize staging belt
+    let mut staging_belt = wgpu::util::StagingBelt::new(5 * 1024);
+
+    let viewport = Viewport::with_physical_size(
+        Size::new(width as u32, height as u32),
+        1.0_f64,
+    );
+    let cursor_position = PhysicalPosition::new(1.0, 1.0);
+
+    let state = program::State::new(
+        appl,
+        viewport.logical_size(),
+        conversion::cursor_position(cursor_position, viewport.scale_factor()),
+        &mut renderer,
+        &mut debug,
+    );
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+    renderer.backend_mut().draw(
+        &mut device,
+        &mut staging_belt,
+        &mut encoder,
+        &texture.create_view(&wgpu::TextureViewDescriptor::default()),
+        &viewport,
+        state.primitive(),
+        &debug.overlay(),
+    );
+```
+
+3. It takes the output buffer and writes it to the disk as a PNG
+```rust
+    // Note that we're not calling `.await` here.
+    let buffer_slice = output_buffer.slice(..);
+    let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+
+    // Poll the device in a blocking manner so that our future resolves.
+    // In an actual application, `device.poll(...)` should
+    // be called in an event loop or on another thread.
+    device.poll(wgpu::Maintain::Wait);
+    // If a file system is available, write the buffer as a PNG
+    let has_file_system_available = cfg!(not(target_arch = "wasm32"));
+    if !has_file_system_available {
+        return;
+    }
+
+    if let Ok(()) = buffer_future.await {
+        let padded_buffer = buffer_slice.get_mapped_range();
+
+        let mut png_encoder = png::Encoder::new(
+            File::create(png_output_path).unwrap(),
+            buffer_dimensions.width as u32,
+            buffer_dimensions.height as u32,
+        );
+        png_encoder.set_depth(png::BitDepth::Eight);
+        png_encoder.set_color(png::ColorType::RGBA);
+        let mut png_writer = png_encoder
+            .write_header()
+            .unwrap()
+            .into_stream_writer_with_size(buffer_dimensions.unpadded_bytes_per_row);
+
+        // from the padded_buffer we write just the unpadded bytes into the image
+        for chunk in padded_buffer.chunks(buffer_dimensions.padded_bytes_per_row) {
+            png_writer
+                .write_all(&chunk[..buffer_dimensions.unpadded_bytes_per_row])
+                .unwrap();
+        }
+        png_writer.finish().unwrap();
+
+        // With the current interface, we have to make sure all mapped views are
+        // dropped before we unmap the buffer.
+        drop(padded_buffer);
+
+        output_buffer.unmap();
+```

--- a/0.3/render_to_framebuffer_and_save/src/counter_app.rs
+++ b/0.3/render_to_framebuffer_and_save/src/counter_app.rs
@@ -1,0 +1,70 @@
+use iced::{button, Align, Button, Element, Text, Row};
+use iced_winit::{Program, Clipboard, Command};
+use iced_wgpu::Renderer;
+
+#[derive(Default)]
+pub struct CounterApp {
+    value: i32,
+    increment_button: button::State,
+    decrement_button: button::State,
+    reset_button: button::State,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Message {
+    IncrementPressed,
+    DecrementPressed,
+    ResetPressed,
+}
+
+impl CounterApp {
+    pub fn new() -> CounterApp {
+        CounterApp {
+            value: Default::default(),
+            increment_button: Default::default(),
+            decrement_button: Default::default(),
+            reset_button: Default::default(),
+        }
+    }
+}
+
+impl Program for CounterApp {
+    type Message = Message;
+
+    fn update(&mut self, message: Message, _clipboard: &mut Clipboard) -> Command<Message>{
+        match message {
+            Message::IncrementPressed => {
+                self.value += 1;
+            }
+            Message::DecrementPressed => {
+                self.value -= 1;
+            }
+            Message::ResetPressed => {
+                self.value = 0;
+            }
+        }
+        Command::none()
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        Row::new()
+            .padding(5)
+            .spacing(20)
+            .align_items(Align::Center)
+            .push(Text::new(self.value.to_string()).size(50))
+            .push(
+                Button::new(&mut self.increment_button, Text::new("Increment"))
+                    .on_press(Message::IncrementPressed),
+            )
+            .push(
+                Button::new(&mut self.decrement_button, Text::new("Decrement"))
+                    .on_press(Message::DecrementPressed),
+            )
+            .push(Button::new(&mut self.reset_button, Text::new("Reset"))
+                .on_press(Message::ResetPressed))
+            .into()
+    }
+
+    type Renderer = Renderer;
+    type Clipboard = Clipboard;
+}

--- a/0.3/render_to_framebuffer_and_save/src/generator.rs
+++ b/0.3/render_to_framebuffer_and_save/src/generator.rs
@@ -1,0 +1,200 @@
+
+use std::mem::size_of;
+use iced_wgpu::{wgpu, Renderer, Backend, Settings, Viewport};
+use iced_wgpu::wgpu::{Device, Buffer};
+use std::fs::File;
+use std::io::Write;
+use iced::{Size};
+use iced_winit::{Debug, conversion, program};
+use iced_winit::winit::dpi::PhysicalPosition;
+
+use crate::counter_app::CounterApp;
+
+pub async fn generate_png() {
+    let counter = CounterApp::new();
+    let (device, buffer, buffer_dimensions) = create_image_with_dimensions(800usize, 200usize, counter).await;
+    create_png("./test.png", device, buffer, &buffer_dimensions).await;
+}
+
+async fn create_image_with_dimensions(
+    width: usize,
+    height: usize,
+    appl: CounterApp
+) -> (Device, Buffer, BufferDimensions) {
+    let adapter = wgpu::Instance::new(wgpu::BackendBit::PRIMARY)
+        .request_adapter(&wgpu::RequestAdapterOptions::default())
+        .await
+        .unwrap();
+
+    let (mut device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                label: None,
+                features: wgpu::Features::empty(),
+                limits: wgpu::Limits::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // It is a WebGPU requirement that ImageCopyBuffer.layout.bytes_per_row % wgpu::COPY_BYTES_PER_ROW_ALIGNMENT == 0
+    // So we calculate padded_bytes_per_row by rounding unpadded_bytes_per_row
+    // up to the next multiple of wgpu::COPY_BYTES_PER_ROW_ALIGNMENT.
+    // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+    let buffer_dimensions = BufferDimensions::new(width, height);
+    // The output buffer lets us retrieve the data as an array
+    let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: (buffer_dimensions.padded_bytes_per_row * buffer_dimensions.height) as u64,
+        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let texture_extent = wgpu::Extent3d {
+        width: buffer_dimensions.width as u32,
+        height: buffer_dimensions.height as u32,
+        depth: 1
+    };
+
+    // The render pipeline renders data into this texture
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: texture_extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+        label: None,
+    });
+
+    let mut debug = Debug::new();
+    let mut renderer = Renderer::new(Backend::new(&mut device, Settings::default()));
+
+    // Initialize staging belt
+    let mut staging_belt = wgpu::util::StagingBelt::new(5 * 1024);
+
+    let viewport = Viewport::with_physical_size(
+        Size::new(width as u32, height as u32),
+        1.0_f64,
+    );
+    let cursor_position = PhysicalPosition::new(1.0, 1.0);
+
+    let state = program::State::new(
+        appl,
+        viewport.logical_size(),
+        conversion::cursor_position(cursor_position, viewport.scale_factor()),
+        &mut renderer,
+        &mut debug,
+    );
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+    renderer.backend_mut().draw(
+        &mut device,
+        &mut staging_belt,
+        &mut encoder,
+        &texture.create_view(&wgpu::TextureViewDescriptor::default()),
+        &viewport,
+        state.primitive(),
+        &debug.overlay(),
+    );
+
+    // Copy the data from the texture to the buffer
+    encoder.copy_texture_to_buffer(
+        wgpu::TextureCopyView {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+        },
+        wgpu::BufferCopyView {
+            buffer: &output_buffer,
+            layout: wgpu::TextureDataLayout {
+                offset: 0,
+                bytes_per_row: buffer_dimensions.padded_bytes_per_row as u32,
+                rows_per_image: buffer_dimensions.height as u32, //
+            },
+        },
+        texture_extent,
+    );
+
+    staging_belt.finish();
+    queue.submit(Some(encoder.finish()));
+
+    (device, output_buffer, buffer_dimensions)
+}
+
+async fn create_png(
+    png_output_path: &str,
+    device: Device,
+    output_buffer: Buffer,
+    buffer_dimensions: &BufferDimensions,
+) {
+    // Note that we're not calling `.await` here.
+    let buffer_slice = output_buffer.slice(..);
+    let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+
+    // Poll the device in a blocking manner so that our future resolves.
+    // In an actual application, `device.poll(...)` should
+    // be called in an event loop or on another thread.
+    device.poll(wgpu::Maintain::Wait);
+    // If a file system is available, write the buffer as a PNG
+    let has_file_system_available = cfg!(not(target_arch = "wasm32"));
+    if !has_file_system_available {
+        return;
+    }
+
+    if let Ok(()) = buffer_future.await {
+        let padded_buffer = buffer_slice.get_mapped_range();
+
+        let mut png_encoder = png::Encoder::new(
+            File::create(png_output_path).unwrap(),
+            buffer_dimensions.width as u32,
+            buffer_dimensions.height as u32,
+        );
+        png_encoder.set_depth(png::BitDepth::Eight);
+        png_encoder.set_color(png::ColorType::RGBA);
+        let mut png_writer = png_encoder
+            .write_header()
+            .unwrap()
+            .into_stream_writer_with_size(buffer_dimensions.unpadded_bytes_per_row);
+
+        // from the padded_buffer we write just the unpadded bytes into the image
+        for chunk in padded_buffer.chunks(buffer_dimensions.padded_bytes_per_row) {
+            png_writer
+                .write_all(&chunk[..buffer_dimensions.unpadded_bytes_per_row])
+                .unwrap();
+        }
+        png_writer.finish().unwrap();
+
+        // With the current interface, we have to make sure all mapped views are
+        // dropped before we unmap the buffer.
+        drop(padded_buffer);
+
+        output_buffer.unmap();
+    }
+}
+
+
+struct BufferDimensions {
+    width: usize,
+    height: usize,
+    unpadded_bytes_per_row: usize,
+    padded_bytes_per_row: usize,
+}
+
+impl BufferDimensions {
+    fn new(width: usize, height: usize) -> Self {
+        let bytes_per_pixel = size_of::<u32>();
+        let unpadded_bytes_per_row = width * bytes_per_pixel;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+        let padded_bytes_per_row_padding = (align - unpadded_bytes_per_row % align) % align;
+        let padded_bytes_per_row = unpadded_bytes_per_row + padded_bytes_per_row_padding;
+        Self {
+            width,
+            height,
+            unpadded_bytes_per_row,
+            padded_bytes_per_row,
+        }
+    }
+}

--- a/0.3/render_to_framebuffer_and_save/src/main.rs
+++ b/0.3/render_to_framebuffer_and_save/src/main.rs
@@ -1,0 +1,8 @@
+mod counter_app;
+mod generator;
+use generator::generate_png;
+use iced::futures::executor::block_on;
+
+pub fn main() {
+    block_on(generate_png())
+}


### PR DESCRIPTION
Like discussed here: https://iced.zulipchat.com/#narrow/stream/213445-help/topic/offscreen.20rendering

The purpose of this example is, to render a GUI to an off-screen framebuffer and save it to an image. So, it is possible to create "screenshots" of an app without actually opening a window of the OS.

It is based on [this](https://github.com/hecrj/iced/tree/master/examples/integration) Iced example in combination with [this](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/capture) wgpu example.
